### PR TITLE
feat: added sharing and fixed everything

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -5,6 +5,7 @@ const MongoStore = require("connect-mongo");
 const connectDB = require("./config/database");
 const authRoutes = require("./routes/authRoutes");
 const workspacesRoutes = require('./routes/workspacesRoutes');
+const shareRoutes = require('./routes/share');
 
 const app = express();
 
@@ -40,6 +41,7 @@ app.use(session({
 // Routes
 app.use("/api/auth", authRoutes);
 app.use('/api/v1/workspaces', workspacesRoutes);
+app.use('/api', shareRoutes);
 
 // Health check
 app.get('/api/health', (req, res) => {

--- a/backend/src/controllers/__tests__/shareController.test.js
+++ b/backend/src/controllers/__tests__/shareController.test.js
@@ -1,0 +1,137 @@
+jest.mock('../../models/Workspace', () => ({
+  findOne: jest.fn(),
+  create: jest.fn(),
+}));
+
+jest.mock('../../models/ShareSnapshot', () => ({
+  findOne: jest.fn(),
+  create: jest.fn(),
+  updateOne: jest.fn(),
+}));
+
+jest.mock('../../models/Activity', () => ({
+  create: jest.fn(),
+}));
+
+jest.mock('../../services/shareService', () => ({
+  createWorkspaceSnapshot: jest.fn(),
+  generateShareToken: jest.fn(),
+  restoreWorkspaceSnapshot: jest.fn(),
+}));
+
+jest.mock('../../services/dockerService', () => ({
+  launchWorkspace: jest.fn(),
+}));
+
+const Workspace = require('../../models/Workspace');
+const ShareSnapshot = require('../../models/ShareSnapshot');
+const Activity = require('../../models/Activity');
+const shareService = require('../../services/shareService');
+const dockerService = require('../../services/dockerService');
+const shareController = require('../shareController');
+
+function createRes() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+}
+
+describe('shareController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  describe('createShareLink', () => {
+    test('rejects non-Python workspaces before snapshotting', async () => {
+      Workspace.findOne.mockResolvedValue({
+        workspaceId: 'ws-1',
+        template: 'mern',
+        status: 'running',
+      });
+
+      const req = {
+        session: { userId: 'user-1' },
+        params: { workspaceId: 'ws-1' },
+        body: { expiresIn: 24, maxClones: 3 },
+      };
+      const res = createRes();
+
+      await shareController.createShareLink(req, res);
+
+      expect(Workspace.findOne).toHaveBeenCalledWith({
+        workspaceId: 'ws-1',
+        userId: 'user-1',
+      });
+      expect(shareService.createWorkspaceSnapshot).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Only Python workspaces can be shared currently',
+      });
+    });
+  });
+
+  describe('cloneWorkspace', () => {
+    test('stores the cloned workspace idePort from dockerService', async () => {
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation((fn) => {
+        fn();
+        return 0;
+      });
+
+      const shareSnapshot = {
+        template: 'python',
+        snapshot: { files: [], packages: [] },
+        description: 'Shared project',
+        name: 'Demo Workspace',
+        isValid: jest.fn().mockReturnValue(true),
+        incrementCloneCount: jest.fn().mockResolvedValue(undefined),
+      };
+      const createdWorkspace = {
+        _id: 'workspace-db-id',
+        workspaceId: 'user-1-python-123',
+        name: 'Demo Workspace (Copy)',
+        template: 'python',
+        status: 'running',
+      };
+
+      ShareSnapshot.findOne.mockResolvedValue(shareSnapshot);
+      dockerService.launchWorkspace.mockResolvedValue({
+        containerId: 'container-123',
+        idePort: 4321,
+        ideUrl: 'http://localhost:4321',
+      });
+      shareService.restoreWorkspaceSnapshot.mockResolvedValue(undefined);
+      Workspace.create.mockResolvedValue(createdWorkspace);
+      Activity.create.mockResolvedValue(undefined);
+
+      const req = {
+        session: { userId: 'user-1' },
+        params: { shareToken: 'share-token' },
+        body: { customName: 'Demo Workspace (Copy)' },
+      };
+      const res = createRes();
+
+      await shareController.cloneWorkspace(req, res);
+
+      expect(Workspace.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          containerId: 'container-123',
+          idePort: 4321,
+          template: 'python',
+          userId: 'user-1',
+        })
+      );
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          workspace: expect.objectContaining({
+            ideUrl: 'http://localhost:4321',
+          }),
+        })
+      );
+      expect(shareSnapshot.incrementCloneCount).toHaveBeenCalled();
+      setTimeoutSpy.mockRestore();
+    });
+  });
+});

--- a/backend/src/controllers/shareController.js
+++ b/backend/src/controllers/shareController.js
@@ -28,10 +28,10 @@ const shareController = {
         return res.status(404).json({ error: 'Workspace not found' });
       }
 
-      // Only support Python for now
+      // Sharing support is only implemented end-to-end for Python workspaces.
       if (workspace.template !== 'python') {
-        return res.status(400).json({ 
-          error: 'Only Python workspaces can be shared currently' 
+        return res.status(400).json({
+          error: 'Only Python workspaces can be shared currently'
         });
       }
 
@@ -215,7 +215,7 @@ const shareController = {
         userId: req.session.userId,
         template: shareSnapshot.template,
         containerId: containerInfo.containerId,
-        idePort: containerInfo.port,
+        idePort: containerInfo.idePort,
         clonedFrom: shareToken
       });
 

--- a/backend/src/models/Activity.js
+++ b/backend/src/models/Activity.js
@@ -23,7 +23,10 @@ const activitySchema = new mongoose.Schema({
       'workspace_deleted',
       'command_executed',
       'collaborator_added',
-      'user_login'
+      'user_login',
+      'workspace_shared',
+      'workspace_cloned',
+      'share_revoked'
     ]
   },
   details: {

--- a/backend/src/models/ShareSnapshot.js
+++ b/backend/src/models/ShareSnapshot.js
@@ -73,10 +73,12 @@ shareSnapshotSchema.methods.isValid = function() {
   return true;
 };
 
-// Method to increment clone count
+// Method to increment clone count (atomic)
 shareSnapshotSchema.methods.incrementCloneCount = async function() {
-  this.cloneCount += 1;
-  return this.save();
+  return mongoose.model('ShareSnapshot').updateOne(
+    { _id: this._id },
+    { $inc: { cloneCount: 1 } }
+  );
 };
 
 module.exports = mongoose.model('ShareSnapshot', shareSnapshotSchema);

--- a/backend/src/models/Workspace.js
+++ b/backend/src/models/Workspace.js
@@ -46,6 +46,20 @@ const workspaceSchema = new mongoose.Schema({
     default: 1
   },
   
+  // Sharing
+  isShared: {
+    type: Boolean,
+    default: false
+  },
+  shareToken: {
+    type: String,
+    default: null
+  },
+  clonedFrom: {
+    type: String,
+    default: null
+  },
+
   // Collaboration
   collaborators: [{
     type: mongoose.Schema.Types.ObjectId,

--- a/backend/src/routes/workspacesRoutes.js
+++ b/backend/src/routes/workspacesRoutes.js
@@ -182,11 +182,12 @@ router.post('/:workspaceId/start', isAuthenticated, async (req, res) => {
     // Resume Docker container
     const result = await dockerService.resumeWorkspace(workspaceId);
     
-    // Update workspace status in database
+    // Update workspace status and port in database
     const workspace = await Workspace.findOneAndUpdate(
       { workspaceId, userId: req.session.userId },
-      { 
+      {
         status: 'running',
+        idePort: result.idePort,
         lastAccessed: new Date()
       },
       { new: true }

--- a/backend/src/services/dockerService.js
+++ b/backend/src/services/dockerService.js
@@ -1,13 +1,14 @@
     // backend/src/services/dockerService.js
 
     const Docker = require('dockerode');
+    const { PassThrough } = require('stream');
 
     let docker;
 
     const TEMPLATE_IMAGES = {
         'python': 'devpod-python:latest',
-        'nodejs': 'devpod-nodejs:latest', 
-        'mern': 'devpod/mern:latest',
+        'nodejs': 'devpod-nodejs:latest',
+        'mern': 'devpod-mern:latest',
         'java': 'devpod-java:latest',
     };
 
@@ -216,7 +217,7 @@
             // Return same structure for ALL templates
             return {
                 containerId: container.id,
-                port: idePort,
+                idePort: idePort,
                 ideUrl: `http://localhost:${idePort}`,
             };
 
@@ -256,8 +257,8 @@
             const info = await container.inspect();
             const idePort = info.NetworkSettings.Ports['8080/tcp'][0].HostPort;
 
-            return { 
-                port: idePort,
+            return {
+                idePort: idePort,
                 ideUrl: `http://localhost:${idePort}`,
             };
         } catch (error) {
@@ -308,15 +309,52 @@
                 Cmd: cmd,
                 AttachStdout: true,
                 AttachStderr: true,
+                // Callers parse stdout as raw data (paths, file contents), so avoid PTY formatting.
+                Tty: false,
             });
-            
+
             const stream = await exec.start({ hijack: true, stdin: false });
-            
+
             return new Promise((resolve, reject) => {
-                let output = '';
-                stream.on('data', (chunk) => { output += chunk.toString(); });
-                stream.on('end', () => { resolve(output); });
-                stream.on('error', reject);
+                let stdout = '';
+                let stderr = '';
+                const stdoutStream = new PassThrough();
+                const stderrStream = new PassThrough();
+                let settled = false;
+
+                const rejectOnce = (error) => {
+                    if (settled) return;
+                    settled = true;
+                    reject(error);
+                };
+
+                const finalize = async () => {
+                    if (settled) return;
+
+                    try {
+                        const { ExitCode } = await exec.inspect();
+                        if (ExitCode !== 0) {
+                            const message = stderr.trim() || stdout.trim() || `Command exited with code ${ExitCode}`;
+                            return rejectOnce(new Error(message));
+                        }
+
+                        settled = true;
+                        resolve(stdout);
+                    } catch (error) {
+                        rejectOnce(error);
+                    }
+                };
+
+                // Strip the 8-byte multiplex headers so we get clean output
+                docker.modem.demuxStream(stream, stdoutStream, stderrStream);
+
+                stdoutStream.on('data', (chunk) => { stdout += chunk.toString(); });
+                stderrStream.on('data', (chunk) => { stderr += chunk.toString(); });
+                stdoutStream.on('error', rejectOnce);
+                stderrStream.on('error', rejectOnce);
+                stream.on('end', () => { void finalize(); });
+                stream.on('close', () => { void finalize(); });
+                stream.on('error', rejectOnce);
             });
         } catch (error) {
             console.error(`❌ Failed to execute command in ${workspaceId}:`, error.message);

--- a/backend/src/services/shareService.js
+++ b/backend/src/services/shareService.js
@@ -109,11 +109,11 @@ async function restoreWorkspaceSnapshot(workspaceId, snapshot) {
           ]);
         }
         
-        // Write file content (escape single quotes in content)
-        const escapedContent = file.content.replace(/'/g, "'\\''");
+        // Write file content safely using base64 encoding
+        const b64 = Buffer.from(file.content).toString('base64');
         await dockerService.execInContainer(workspaceId, [
           'bash', '-c',
-          `cat > '${fullPath}' << 'EOF'\n${file.content}\nEOF`
+          `echo '${b64}' | base64 -d > '${fullPath}'`
         ]);
         
         console.log(`✅ Restored: ${file.path}`);
@@ -128,11 +128,11 @@ async function restoreWorkspaceSnapshot(workspaceId, snapshot) {
       console.log(`📦 Installing ${snapshot.packages.length} Python packages...`);
       
       try {
-        // Create requirements.txt
-        const requirementsContent = snapshot.packages.join('\n');
+        // Create requirements.txt safely using base64
+        const reqB64 = Buffer.from(snapshot.packages.join('\n')).toString('base64');
         await dockerService.execInContainer(workspaceId, [
           'bash', '-c',
-          `echo '${requirementsContent}' > /workspace/requirements.txt`
+          `echo '${reqB64}' | base64 -d > /workspace/requirements.txt`
         ]);
         
         // Install packages

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import LandingPage from './pages/LandingPage/LandingPage';
 import Dashboard from './pages/Dashboard/Dashboard';
 import AuthCallback from './pages/AuthCallback/AuthCallback';
+import SharePreview from './pages/SharePreview/SharePreview';
 import ProtectedRoute from './components/ProtectedRoute';
 import './App.css';
 
@@ -14,6 +15,9 @@ function App() {
 
         {/* GitHub OAuth Callback */}
         <Route path="/auth/callback" element={<AuthCallback />} />
+
+        {/* Share Preview (public) */}
+        <Route path="/share/:shareToken" element={<SharePreview />} />
 
         {/* Protected Dashboard page */}
         <Route

--- a/frontend/src/components/ShareWorkspaceModal.jsx
+++ b/frontend/src/components/ShareWorkspaceModal.jsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { QRCodeSVG } from 'qrcode.react';
 import './ShareWorkspaceModal.css';
 
 export default function ShareWorkspaceModal({ workspace, onClose }) {

--- a/frontend/src/pages/Dashboard/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard/Dashboard.jsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { 
-  Github, Monitor, Rocket, Code, Settings, Plus, Search,
-  Users, Clock, FolderOpen, GitBranch, Share2, Play, Activity, LogOut
+import {
+  Monitor, Rocket, Code, Settings, Plus, Search,
+  Users, Clock, FolderOpen, GitBranch, Share2, Play, Activity, LogOut,
+  Square, Trash2
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
+import ShareWorkspaceModal from '../../components/ShareWorkspaceModal';
 
 const Dashboard = () => {
   const navigate = useNavigate();
@@ -12,65 +14,68 @@ const Dashboard = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [filterType, setFilterType] = useState('all');
   const [user, setUser] = useState(null);
-  // NEW STATE: Tracks the ID of the template currently being launched
-  const [launchingTemplateId, setLaunchingTemplateId] = useState(null); 
+  const [launchingTemplateId, setLaunchingTemplateId] = useState(null);
   const [stats, setStats] = useState({
-    activeWorkspaces: 2,
-    totalProjects: 12,
-    collaborators: 6,
-    hoursSaved: 84
+    activeWorkspaces: 0,
+    totalProjects: 0,
+    collaborators: 0,
+    hoursSaved: 0
   });
   const [workspaces, setWorkspaces] = useState([]);
+  const [activities, setActivities] = useState([]);
+  const [actionLoading, setActionLoading] = useState(null);
+  const [shareWorkspace, setShareWorkspace] = useState(null);
 
-  // Load user from localStorage
   useEffect(() => {
     const storedUser = localStorage.getItem("user");
     if (storedUser) {
       setUser(JSON.parse(storedUser));
     }
-    
-    // Load dashboard stats
     loadDashboardData();
   }, []);
 
-  // Load dashboard data from backend
   const loadDashboardData = async () => {
-    // ... (Your loadDashboardData function remains the same)
     try {
-      // Get dashboard stats
       const statsResponse = await fetch(`${import.meta.env.VITE_API_URL}/api/v1/workspaces/dashboard/stats`, {
         credentials: 'include'
       });
-      
       if (statsResponse.ok) {
         const statsData = await statsResponse.json();
         setStats(statsData);
       }
 
-      // Get workspaces list
       const workspacesResponse = await fetch(`${import.meta.env.VITE_API_URL}/api/v1/workspaces/list`, {
         credentials: 'include'
       });
-      
       if (workspacesResponse.ok) {
         const workspacesData = await workspacesResponse.json();
         setWorkspaces(workspacesData);
       }
     } catch (error) {
       console.error('Error loading dashboard data:', error);
-      // Keep using mock data if API fails
     }
   };
 
-  // Logout function
+  const loadActivities = async () => {
+    try {
+      const response = await fetch(`${import.meta.env.VITE_API_URL}/api/v1/workspaces/activity/recent`, {
+        credentials: 'include'
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setActivities(data);
+      }
+    } catch (error) {
+      console.error('Error loading activities:', error);
+    }
+  };
+
   const handleLogout = async () => {
-    // ... (Your handleLogout function remains the same)
     try {
       await fetch(`${import.meta.env.VITE_API_URL}/api/auth/logout`, {
         method: 'POST',
         credentials: 'include'
       });
-      
       localStorage.removeItem('user');
       localStorage.removeItem('isLoggedIn');
       navigate('/');
@@ -79,164 +84,167 @@ const Dashboard = () => {
     }
   };
 
-  // Launch Workspace function with proper authentication
-  const launchWorkspace = async (template) => { 
-    // Set loading state for this specific template
-    setLaunchingTemplateId(template.id); 
+  const openPendingIdeTab = () => window.open('about:blank', '_blank');
+
+  const navigateToIde = (ideTab, ideUrl) => {
+    if (ideTab && !ideTab.closed) {
+      ideTab.location.href = ideUrl;
+      return;
+    }
+    window.open(ideUrl, '_blank');
+  };
+
+  const closePendingIdeTab = (ideTab) => {
+    if (ideTab && !ideTab.closed) {
+      ideTab.close();
+    }
+  };
+
+  const launchWorkspace = async (template) => {
+    setLaunchingTemplateId(template.id);
 
     let templateKey;
-    
-    // Map display name to backend's required key
-    if (template.name.includes('Python')) {
-      templateKey = 'python';
-    } else if (template.name.includes('Node.js')) {
-      templateKey = 'nodejs';
-    } else if (template.name.includes('MERN')) {
-      templateKey = 'mern';
-    } else if (template.name.includes('Java')) {
-      templateKey = 'java';
-    } else {
+    if (template.name.includes('Python')) templateKey = 'python';
+    else if (template.name.includes('Node.js')) templateKey = 'nodejs';
+    else if (template.name.includes('MERN')) templateKey = 'mern';
+    else if (template.name.includes('Java')) templateKey = 'java';
+    else {
       alert(`Template ${template.name} is not configured.`);
       setLaunchingTemplateId(null);
       return;
     }
 
-    console.log(`🚀 Launching ${templateKey} workspace via API...`);
-    
+    const ideTab = openPendingIdeTab();
+
     try {
       const response = await fetch(`${import.meta.env.VITE_API_URL}/api/v1/workspaces/launch`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include', // Send cookies for authentication
-        body: JSON.stringify({ 
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
           template: templateKey,
           name: `${templateKey}-workspace-${Date.now()}`,
           description: `Workspace created from ${template.name} template`
         })
       });
 
-      // Parse response
       const data = await response.json();
-      
+
       if (!response.ok) {
-        console.error('❌ Launch failed:', response.status, data);
-        
-        // Handle specific error cases
         if (response.status === 401) {
+          closePendingIdeTab(ideTab);
           alert('Session expired. Please login again.');
           navigate('/');
           return;
-        } else if (response.status === 503 && data.message?.includes('Docker')) {
-          alert('Docker is not running. Please start Docker Desktop and try again.');
-          return;
-        } else if (response.status === 502 && data.message?.includes('internet')) {
-          alert('Failed to download required files. Please check your internet connection and try again.');
-          return;
-        } else if (response.status === 400) {
-          alert(`Configuration error: ${data.message || 'Invalid template selected'}`);
-          return;
         }
-        
-        // Generic error message with details
+        closePendingIdeTab(ideTab);
         const errorMsg = data.message || data.error || `Server error (${response.status})`;
         alert(`Failed to launch workspace: ${errorMsg}`);
         return;
       }
 
-      // Success case
-      console.log('✅ Workspace launched successfully:', data);
-      
       const ideUrl = data.ideUrl;
       if (!ideUrl) {
         throw new Error('No IDE URL received from server');
       }
-      
-      console.log(`🎉 Workspace ready. Opening: ${ideUrl}`);
-      
-      // Show success message
-      alert(`🎉 ${template.name} workspace is ready! Opening in new tab...`);
-      
-      // Reload dashboard data to show new workspace
+
+      navigateToIde(ideTab, ideUrl);
       await loadDashboardData();
-      
-      // Open the new DevPod IDE in a new tab
-      window.open(ideUrl, '_blank');
 
     } catch (error) {
-      console.error("❌ Failed to launch DevPod:", error);
-      
-      // Handle network errors
-      if (error.message.includes('fetch')) {
-        alert("Network error. Please check your connection and try again.");
-      } else if (error.message.includes('IDE URL')) {
-        alert("Workspace created but failed to get access URL. Please check the dashboard.");
-      } else {
-        alert(`Failed to start workspace: ${error.message}`);
-      }
+      closePendingIdeTab(ideTab);
+      console.error("Failed to launch DevPod:", error);
+      alert(`Failed to start workspace: ${error.message}`);
     } finally {
-      // Clear loading state
-      setLaunchingTemplateId(null); 
+      setLaunchingTemplateId(null);
     }
   };
 
-  // Mock data for templates 
-  const templates = [
-    {
-      id: 3,
-      name: 'Python Development',
-      description: 'Python environment with code-server IDE',
-      icon: '🐍',
-      tags: ['Backend', 'Python', 'API'],
-      featured: false,
-      uses: 120
-    },
-    {
-      id: 4,
-      name: 'Node.js Backend',
-      description: 'Node.js and Express development environment',
-      icon: '⚙️',
-      tags: ['Backend', 'Node.js', 'Express'],
-      featured: false,
-      uses: 80
-    },
-    {
-      id: 5,
-      name: 'MERN Stack',
-      description: 'MongoDB, Express, React, Node.js full-stack environment',
-      icon: '🍃',
-      tags: ['Full-Stack', 'MongoDB', 'React'],
-      featured: true,
-      uses: 200
-    },
-    {
-      id: 6,
-      name: 'Java Development',
-      description: 'Java 17 with Maven, Gradle, and code-server IDE',
-      icon: '☕',
-      tags: ['Backend', 'Java', 'Maven', 'Gradle'],
-      featured: false,
-      uses: 95
+  const stopWorkspace = async (workspaceId) => {
+    setActionLoading(workspaceId);
+    try {
+      const response = await fetch(`${import.meta.env.VITE_API_URL}/api/v1/workspaces/${workspaceId}/stop`, {
+        method: 'POST',
+        credentials: 'include'
+      });
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || 'Failed to stop workspace');
+      }
+      await loadDashboardData();
+    } catch (error) {
+      alert(`Failed to stop workspace: ${error.message}`);
+    } finally {
+      setActionLoading(null);
     }
+  };
+
+  const startWorkspace = async (workspaceId) => {
+    setActionLoading(workspaceId);
+    const ideTab = openPendingIdeTab();
+
+    try {
+      const response = await fetch(`${import.meta.env.VITE_API_URL}/api/v1/workspaces/${workspaceId}/start`, {
+        method: 'POST',
+        credentials: 'include'
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to start workspace');
+      }
+      if (!data.ideUrl) {
+        throw new Error('No IDE URL received from server');
+      }
+
+      navigateToIde(ideTab, data.ideUrl);
+      await loadDashboardData();
+    } catch (error) {
+      closePendingIdeTab(ideTab);
+      alert(`Failed to start workspace: ${error.message}`);
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const deleteWorkspace = async (workspaceId, workspaceName) => {
+    if (!confirm(`Are you sure you want to delete "${workspaceName}"? This cannot be undone.`)) {
+      return;
+    }
+    setActionLoading(workspaceId);
+    try {
+      const response = await fetch(`${import.meta.env.VITE_API_URL}/api/v1/workspaces/${workspaceId}`, {
+        method: 'DELETE',
+        credentials: 'include'
+      });
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || 'Failed to delete workspace');
+      }
+      await loadDashboardData();
+    } catch (error) {
+      alert(`Failed to delete workspace: ${error.message}`);
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const templates = [
+    { id: 3, name: 'Python Development', description: 'Python environment with code-server IDE', icon: '🐍', tags: ['Backend', 'Python', 'API'], uses: 120 },
+    { id: 4, name: 'Node.js Backend', description: 'Node.js and Express development environment', icon: '⚙️', tags: ['Backend', 'Node.js', 'Express'], uses: 80 },
+    { id: 5, name: 'MERN Stack', description: 'MongoDB, Express, React, Node.js full-stack environment', icon: '🍃', tags: ['Full-Stack', 'MongoDB', 'React'], featured: true, uses: 200 },
+    { id: 6, name: 'Java Development', description: 'Java 17 with Maven, Gradle, and code-server IDE', icon: '☕', tags: ['Backend', 'Java', 'Maven', 'Gradle'], uses: 95 }
   ];
 
-  // ... (Your animation variants and utility functions remain the same)
   const fadeInUp = {
     hidden: { opacity: 0, y: 20 },
-    visible: { 
-      opacity: 1, 
-      y: 0,
+    visible: {
+      opacity: 1, y: 0,
       transition: { duration: 0.5, ease: [0.25, 0.46, 0.45, 0.94] }
     }
   };
 
   const stagger = {
-    visible: {
-      transition: {
-        staggerChildren: 0.1
-      }
-    }
+    visible: { transition: { staggerChildren: 0.1 } }
   };
 
   const getStatusColor = (status) => {
@@ -246,6 +254,22 @@ const Dashboard = () => {
       case 'starting': return 'text-yellow-400 bg-yellow-400/10';
       default: return 'text-slate-400 bg-slate-400/10';
     }
+  };
+
+  const formatAction = (action) => {
+    const labels = {
+      workspace_created: 'Created workspace',
+      workspace_launched: 'Launched workspace',
+      workspace_stopped: 'Stopped workspace',
+      workspace_resumed: 'Resumed workspace',
+      workspace_deleted: 'Deleted workspace',
+      workspace_shared: 'Shared workspace',
+      workspace_cloned: 'Cloned workspace',
+      share_revoked: 'Revoked share link',
+      command_executed: 'Executed command',
+      user_login: 'Logged in',
+    };
+    return labels[action] || action;
   };
 
   const filteredWorkspaces = workspaces.filter(workspace => {
@@ -258,17 +282,14 @@ const Dashboard = () => {
   return (
     <div className="bg-slate-900 text-white min-h-screen">
       {/* Navigation */}
-      <motion.nav 
+      <motion.nav
         initial={{ y: -100 }}
         animate={{ y: 0 }}
         className="bg-slate-900/90 backdrop-blur-md border-b border-slate-800 sticky top-0 z-50"
       >
         <div className="max-w-7xl mx-auto px-6 py-4">
           <div className="flex items-center justify-between">
-            <motion.div 
-              className="flex items-center space-x-2"
-              whileHover={{ scale: 1.05 }}
-            >
+            <motion.div className="flex items-center space-x-2" whileHover={{ scale: 1.05 }}>
               <div className="w-8 h-8 bg-emerald-500 rounded-lg flex items-center justify-center">
                 <Code className="w-5 h-5" />
               </div>
@@ -279,25 +300,16 @@ const Dashboard = () => {
               {user && (
                 <div className="flex items-center space-x-2 text-sm text-slate-300">
                   {user.avatar_url ? (
-                    <img
-                      src={user.avatar_url}
-                      alt={user.login}
-                      className="w-8 h-8 rounded-full border border-slate-700"
-                    />
+                    <img src={user.avatar_url} alt={user.login} className="w-8 h-8 rounded-full border border-slate-700" />
                   ) : (
                     <div className="w-8 h-8 bg-slate-700 rounded-full flex items-center justify-center">
-                      <span className="text-xs font-semibold">
-                        {user.login ? user.login[0].toUpperCase() : "?"}
-                      </span>
+                      <span className="text-xs font-semibold">{user.login ? user.login[0].toUpperCase() : "?"}</span>
                     </div>
                   )}
                   <span>{user.name || user.login}</span>
                 </div>
               )}
-              <button className="p-2 hover:bg-slate-800 rounded-lg transition-colors">
-                <Settings className="w-5 h-5" />
-              </button>
-              <button 
+              <button
                 onClick={handleLogout}
                 className="p-2 hover:bg-red-500/10 text-red-400 hover:text-red-300 rounded-lg transition-colors"
                 title="Logout"
@@ -311,12 +323,7 @@ const Dashboard = () => {
 
       <div className="max-w-7xl mx-auto px-6 py-8">
         {/* Header */}
-        <motion.div
-          initial="hidden"
-          animate="visible"
-          variants={stagger}
-          className="mb-8"
-        >
+        <motion.div initial="hidden" animate="visible" variants={stagger} className="mb-8">
           <motion.div variants={fadeInUp} className="flex items-center justify-between mb-6">
             <div>
               <h1 className="text-3xl font-bold mb-2">
@@ -335,13 +342,13 @@ const Dashboard = () => {
             </motion.button>
           </motion.div>
 
-          {/* Stats Cards - Now using real data */}
+          {/* Stats Cards */}
           <motion.div variants={fadeInUp} className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
             {[
-              { label: 'Active Workspaces', value: stats.activeWorkspaces, icon: <Monitor className="w-5 h-5" />, color: 'emerald' },
-              { label: 'Total Projects', value: stats.totalProjects, icon: <FolderOpen className="w-5 h-5" />, color: 'blue' },
-              { label: 'Collaborators', value: stats.collaborators, icon: <Users className="w-5 h-5" />, color: 'purple' },
-              { label: 'Hours Saved', value: stats.hoursSaved, icon: <Clock className="w-5 h-5" />, color: 'orange' }
+              { label: 'Active Workspaces', value: stats.activeWorkspaces, icon: <Monitor className="w-5 h-5" />, colorClass: 'text-emerald-400' },
+              { label: 'Total Projects', value: stats.totalProjects, icon: <FolderOpen className="w-5 h-5" />, colorClass: 'text-blue-400' },
+              { label: 'Collaborators', value: stats.collaborators, icon: <Users className="w-5 h-5" />, colorClass: 'text-purple-400' },
+              { label: 'Hours Saved', value: stats.hoursSaved, icon: <Clock className="w-5 h-5" />, colorClass: 'text-orange-400' }
             ].map((stat, index) => (
               <div key={index} className="bg-slate-800 p-6 rounded-2xl border border-slate-700">
                 <div className="flex items-center justify-between">
@@ -349,7 +356,7 @@ const Dashboard = () => {
                     <p className="text-slate-400 text-sm">{stat.label}</p>
                     <p className="text-2xl font-bold mt-1">{stat.value}</p>
                   </div>
-                  <div className={`text-${stat.color}-400`}>
+                  <div className={stat.colorClass}>
                     {stat.icon}
                   </div>
                 </div>
@@ -359,12 +366,7 @@ const Dashboard = () => {
         </motion.div>
 
         {/* Tab Navigation */}
-        <motion.div
-          initial="hidden"
-          animate="visible"
-          variants={fadeInUp}
-          className="mb-8"
-        >
+        <motion.div initial="hidden" animate="visible" variants={fadeInUp} className="mb-8">
           <div className="flex items-center space-x-1 bg-slate-800 p-1 rounded-xl w-fit">
             {[
               { id: 'workspaces', label: 'My Workspaces', icon: <Monitor className="w-4 h-4" /> },
@@ -373,10 +375,13 @@ const Dashboard = () => {
             ].map((tab) => (
               <button
                 key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
+                onClick={() => {
+                  setActiveTab(tab.id);
+                  if (tab.id === 'activity') loadActivities();
+                }}
                 className={`flex items-center space-x-2 px-4 py-2 rounded-lg transition-all ${
-                  activeTab === tab.id 
-                    ? 'bg-emerald-500 text-white' 
+                  activeTab === tab.id
+                    ? 'bg-emerald-500 text-white'
                     : 'text-slate-400 hover:text-white hover:bg-slate-700'
                 }`}
               >
@@ -391,13 +396,7 @@ const Dashboard = () => {
         <AnimatePresence mode="wait">
           {/* Workspaces Tab */}
           {activeTab === 'workspaces' && (
-            <motion.div
-              key="workspaces"
-              initial="hidden"
-              animate="visible"
-              exit="hidden"
-              variants={stagger}
-            >
+            <motion.div key="workspaces" initial="hidden" animate="visible" exit="hidden" variants={stagger}>
               {/* Search and Filter */}
               <motion.div variants={fadeInUp} className="flex flex-col md:flex-row gap-4 mb-6">
                 <div className="relative flex-1">
@@ -423,10 +422,7 @@ const Dashboard = () => {
 
               {/* Workspaces Grid */}
               {filteredWorkspaces.length === 0 ? (
-                <motion.div 
-                  variants={fadeInUp}
-                  className="text-center py-12 bg-slate-800 rounded-2xl border border-slate-700"
-                >
+                <motion.div variants={fadeInUp} className="text-center py-12 bg-slate-800 rounded-2xl border border-slate-700">
                   <FolderOpen className="w-16 h-16 text-slate-600 mx-auto mb-4" />
                   <h3 className="text-xl font-semibold mb-2">No workspaces yet</h3>
                   <p className="text-slate-400 mb-6">Create your first workspace to get started</p>
@@ -439,73 +435,101 @@ const Dashboard = () => {
                 </motion.div>
               ) : (
                 <motion.div variants={stagger} className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
-                  {filteredWorkspaces.map((workspace) => (
-                    <motion.div
-                      key={workspace._id || workspace.id}
-                      variants={fadeInUp}
-                      whileHover={{ y: -5 }}
-                      className="bg-slate-800 border border-slate-700 rounded-2xl p-6 hover:border-emerald-500/50 transition-all duration-300"
-                    >
-                      <div className="flex items-start justify-between mb-4">
-                        <div className="flex-1">
-                          <div className="flex items-center space-x-2 mb-2">
-                            <h3 className="text-xl font-semibold">{workspace.name}</h3>
-                            <span className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(workspace.status)}`}>
-                              {workspace.status}
-                            </span>
+                  {filteredWorkspaces.map((workspace) => {
+                    const isLoading = actionLoading === workspace.workspaceId;
+                    return (
+                      <motion.div
+                        key={workspace._id || workspace.id}
+                        variants={fadeInUp}
+                        whileHover={{ y: -5 }}
+                        className="bg-slate-800 border border-slate-700 rounded-2xl p-6 hover:border-emerald-500/50 transition-all duration-300"
+                      >
+                        <div className="flex items-start justify-between mb-4">
+                          <div className="flex-1">
+                            <div className="flex items-center space-x-2 mb-2">
+                              <h3 className="text-xl font-semibold">{workspace.name}</h3>
+                              <span className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(workspace.status)}`}>
+                                {workspace.status}
+                              </span>
+                            </div>
+                            <p className="text-slate-400 text-sm mb-3">{workspace.description}</p>
                           </div>
-                          <p className="text-slate-400 text-sm mb-3">{workspace.description}</p>
                         </div>
-                      </div>
 
-                      <div className="flex items-center space-x-4 text-xs text-slate-400 mb-4">
-                        <div className="flex items-center space-x-1">
-                          <Code className="w-4 h-4" />
-                          <span>{workspace.template}</span>
+                        <div className="flex items-center space-x-4 text-xs text-slate-400 mb-4">
+                          <div className="flex items-center space-x-1">
+                            <Code className="w-4 h-4" />
+                            <span>{workspace.template}</span>
+                          </div>
+                          <div className="flex items-center space-x-1">
+                            <GitBranch className="w-4 h-4" />
+                            <span>{workspace.branches || 1}</span>
+                          </div>
+                          <div className="flex items-center space-x-1">
+                            <Users className="w-4 h-4" />
+                            <span>{workspace.collaborators?.length || 0}</span>
+                          </div>
                         </div>
-                        <div className="flex items-center space-x-1">
-                          <GitBranch className="w-4 h-4" />
-                          <span>{workspace.branches}</span>
-                        </div>
-                        <div className="flex items-center space-x-1">
-                          <Users className="w-4 h-4" />
-                          <span>{workspace.collaborators?.length || 0}</span>
-                        </div>
-                      </div>
 
-                      <div className="flex items-center justify-between">
-                        <div>
-                          <p className="text-xs text-slate-500">Last accessed</p>
-                          <p className="text-sm text-slate-300">
-                            {new Date(workspace.lastAccessed).toLocaleDateString()}
-                          </p>
-                        </div>
-                        <div className="flex items-center space-x-2">
-                          {workspace.status === 'running' ? (
-                            <motion.button
-                              onClick={() => window.open(`http://localhost:${workspace.idePort}`, '_blank')}
-                              className="bg-emerald-500 hover:bg-emerald-400 text-white px-4 py-2 rounded-lg text-sm font-medium transition-all"
-                              whileHover={{ scale: 1.05 }}
-                              whileTap={{ scale: 0.95 }}
+                        <div className="flex items-center justify-between">
+                          <div>
+                            <p className="text-xs text-slate-500">Last accessed</p>
+                            <p className="text-sm text-slate-300">
+                              {new Date(workspace.lastAccessed).toLocaleDateString()}
+                            </p>
+                          </div>
+                          <div className="flex items-center space-x-2">
+                            {workspace.status === 'running' ? (
+                              <>
+                                <motion.button
+                                  onClick={() => window.open(`http://localhost:${workspace.idePort}`, '_blank')}
+                                  className="bg-emerald-500 hover:bg-emerald-400 text-white px-4 py-2 rounded-lg text-sm font-medium transition-all"
+                                  whileHover={{ scale: 1.05 }}
+                                  whileTap={{ scale: 0.95 }}
+                                >
+                                  Open
+                                </motion.button>
+                                <button
+                                  onClick={() => setShareWorkspace(workspace)}
+                                  className="p-2 text-blue-400 hover:text-blue-300 hover:bg-blue-500/10 rounded-lg transition-all"
+                                  title="Share"
+                                >
+                                  <Share2 className="w-4 h-4" />
+                                </button>
+                                <button
+                                  onClick={() => stopWorkspace(workspace.workspaceId)}
+                                  disabled={isLoading}
+                                  className="p-2 text-yellow-400 hover:text-yellow-300 hover:bg-yellow-500/10 rounded-lg transition-all disabled:opacity-50"
+                                  title="Stop"
+                                >
+                                  <Square className="w-4 h-4" />
+                                </button>
+                              </>
+                            ) : (
+                              <motion.button
+                                onClick={() => startWorkspace(workspace.workspaceId)}
+                                disabled={isLoading}
+                                className="bg-slate-700 hover:bg-slate-600 text-white px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center space-x-1 disabled:opacity-50"
+                                whileHover={{ scale: 1.05 }}
+                                whileTap={{ scale: 0.95 }}
+                              >
+                                <Play className="w-3 h-3" />
+                                <span>{isLoading ? 'Starting...' : 'Start'}</span>
+                              </motion.button>
+                            )}
+                            <button
+                              onClick={() => deleteWorkspace(workspace.workspaceId, workspace.name)}
+                              disabled={isLoading}
+                              className="p-2 text-red-400 hover:text-red-300 hover:bg-red-500/10 rounded-lg transition-all disabled:opacity-50"
+                              title="Delete"
                             >
-                              Open
-                            </motion.button>
-                          ) : (
-                            <motion.button
-                              className="bg-slate-700 hover:bg-slate-600 text-white px-4 py-2 rounded-lg text-sm font-medium transition-all"
-                              whileHover={{ scale: 1.05 }}
-                              whileTap={{ scale: 0.95 }}
-                            >
-                              Start
-                            </motion.button>
-                          )}
-                          <button className="p-2 text-slate-400 hover:text-white hover:bg-slate-700 rounded-lg transition-all">
-                            <Settings className="w-4 h-4" />
-                          </button>
+                              <Trash2 className="w-4 h-4" />
+                            </button>
+                          </div>
                         </div>
-                      </div>
-                    </motion.div>
-                  ))}
+                      </motion.div>
+                    );
+                  })}
                 </motion.div>
               )}
             </motion.div>
@@ -513,21 +537,12 @@ const Dashboard = () => {
 
           {/* Templates Tab */}
           {activeTab === 'templates' && (
-            <motion.div
-              key="templates"
-              initial="hidden"
-              animate="visible"
-              exit="hidden"
-              variants={stagger}
-            >
-              {/* All Templates */}
+            <motion.div key="templates" initial="hidden" animate="visible" exit="hidden" variants={stagger}>
               <motion.div variants={fadeInUp}>
                 <h2 className="text-2xl font-bold mb-4">All Templates</h2>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
                   {templates.map((template) => {
-                    // Check if this specific template is currently launching
                     const isTemplateLaunching = launchingTemplateId === template.id;
-
                     return (
                       <motion.div
                         key={template.id}
@@ -543,21 +558,12 @@ const Dashboard = () => {
                           </div>
                         </div>
                         <motion.button
-                          onClick={() => {
-                            if (template.url && template.name === 'React + Vite') {
-                              window.open(template.url, "_blank");
-                            } else {
-                              // Pass the full template object to the launch function
-                              launchWorkspace(template); 
-                            }
-                          }}
+                          onClick={() => launchWorkspace(template)}
                           className="w-full bg-slate-700 hover:bg-slate-600 text-white py-2 rounded-lg text-sm font-medium transition-all"
                           whileHover={{ scale: 1.02 }}
                           whileTap={{ scale: 0.98 }}
-                          // Use the specific launching state for the disabled prop
-                          disabled={isTemplateLaunching} 
+                          disabled={isTemplateLaunching}
                         >
-                          {/* Display the correct text based on the specific template's loading state */}
                           {isTemplateLaunching ? 'Launching...' : 'Use'}
                         </motion.button>
                       </motion.div>
@@ -570,26 +576,47 @@ const Dashboard = () => {
 
           {/* Activity Tab */}
           {activeTab === 'activity' && (
-            <motion.div
-              key="activity"
-              initial="hidden"
-              animate="visible"
-              exit="hidden"
-              variants={stagger}
-            >
+            <motion.div key="activity" initial="hidden" animate="visible" exit="hidden" variants={stagger}>
               <motion.div variants={fadeInUp} className="bg-slate-800 border border-slate-700 rounded-2xl p-6">
                 <h2 className="text-2xl font-bold mb-6">Recent Activity</h2>
                 <div className="space-y-4">
-                  <div className="text-center py-8 text-slate-400">
-                    <Activity className="w-12 h-12 mx-auto mb-4 opacity-50" />
-                    <p>Your recent activity will appear here</p>
-                  </div>
+                  {activities.length === 0 ? (
+                    <div className="text-center py-8 text-slate-400">
+                      <Activity className="w-12 h-12 mx-auto mb-4 opacity-50" />
+                      <p>No activity yet. Launch a workspace to get started!</p>
+                    </div>
+                  ) : (
+                    activities.map((activity) => (
+                      <div key={activity._id} className="flex items-center space-x-4 p-4 bg-slate-700/50 rounded-xl">
+                        <div className="w-10 h-10 bg-emerald-500/10 rounded-full flex items-center justify-center">
+                          <Activity className="w-5 h-5 text-emerald-400" />
+                        </div>
+                        <div className="flex-1">
+                          <p className="text-sm font-medium">{formatAction(activity.action)}</p>
+                          <p className="text-xs text-slate-400">
+                            {activity.workspaceId?.name || ''}
+                          </p>
+                        </div>
+                        <p className="text-xs text-slate-500">
+                          {new Date(activity.timestamp).toLocaleString()}
+                        </p>
+                      </div>
+                    ))
+                  )}
                 </div>
               </motion.div>
             </motion.div>
           )}
         </AnimatePresence>
       </div>
+
+      {/* Share Workspace Modal */}
+      {shareWorkspace && (
+        <ShareWorkspaceModal
+          workspace={shareWorkspace}
+          onClose={() => setShareWorkspace(null)}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/SharePreview/SharePreview.jsx
+++ b/frontend/src/pages/SharePreview/SharePreview.jsx
@@ -9,11 +9,28 @@ export default function SharePreview() {
   const [cloning, setCloning] = useState(false);
   const [shareData, setShareData] = useState(null);
   const [error, setError] = useState('');
+  const [cloneError, setCloneError] = useState('');
   const [customName, setCustomName] = useState('');
 
   useEffect(() => {
     fetchSharePreview();
   }, [shareToken]);
+
+  const openPendingIdeTab = () => window.open('about:blank', '_blank');
+
+  const navigateToIde = (ideTab, ideUrl) => {
+    if (ideTab && !ideTab.closed) {
+      ideTab.location.href = ideUrl;
+      return;
+    }
+    window.open(ideUrl, '_blank');
+  };
+
+  const closePendingIdeTab = (ideTab) => {
+    if (ideTab && !ideTab.closed) {
+      ideTab.close();
+    }
+  };
 
   const fetchSharePreview = async () => {
     try {
@@ -41,7 +58,8 @@ export default function SharePreview() {
 
   const handleClone = async () => {
     setCloning(true);
-    setError('');
+    setCloneError('');
+    const ideTab = openPendingIdeTab();
 
     try {
       const response = await fetch(
@@ -60,20 +78,15 @@ export default function SharePreview() {
         throw new Error(data.error || 'Failed to clone workspace');
       }
 
-      // Open the cloned workspace IDE directly
-      alert('Workspace cloned successfully! Opening your workspace...');
-      
-      // Open IDE in new tab
-      if (data.workspace.ideUrl) {
-        window.open(data.workspace.ideUrl, '_blank');
+      if (!data.workspace?.ideUrl) {
+        throw new Error('No IDE URL received from server');
       }
-      
-      // Redirect to dashboard after a short delay
-      setTimeout(() => {
-        navigate('/dashboard');
-      }, 1000);
+
+      navigateToIde(ideTab, data.workspace.ideUrl);
+      navigate('/dashboard');
     } catch (err) {
-      setError(err.message);
+      closePendingIdeTab(ideTab);
+      setCloneError(err.message);
       setCloning(false);
     }
   };
@@ -178,7 +191,7 @@ export default function SharePreview() {
 
           {shareData.packages && shareData.packages.length > 0 && (
             <div className="packages-section">
-              <h3>Python Packages</h3>
+              <h3>Packages</h3>
               <div className="packages-list">
                 {shareData.packages.map((pkg, index) => (
                   <span key={index} className="package-badge">
@@ -206,7 +219,7 @@ export default function SharePreview() {
               />
             </div>
 
-            {error && <div className="error-message">{error}</div>}
+            {cloneError && <div className="error-message">{cloneError}</div>}
 
             <button
               onClick={handleClone}


### PR DESCRIPTION
⏺ **What Was Fixed & How to Test**

  1. **"Open" button was broken** — Clicking `Open` on the dashboard could send you to the wrong place. Now it opens the workspace IDE correctly.  
  Test: launch a workspace, refresh the dashboard, click `Open`.

  2. **Sharing wasn’t connected** — The sharing pieces existed, but they were not all hooked together. Now the Share button, share link, preview page, and clone flow work together for Python workspaces.  
  Test: click the share icon on a running Python workspace, generate a link, and open it in another browser/profile on the same computer.

  3. **Sharing could throw backend errors** — Sharing, cloning, and revoking could fail because the app was missing some of the data it needed to save. Now those basic save steps work properly.  
  Test: share a Python workspace, clone it, then revoke the link without getting server errors.

  4. **Clone failure wiped the page** — If cloning failed, the whole preview page could disappear. Now it shows a small error message and lets you try again.  
  Test: open a share link while logged out and click `Clone Workspace`.

  5. **IDE tabs could get blocked by the browser** — After launch, start, or clone, the IDE tab could silently fail to open. Now the app opens the tab in a browser-safe way.  
  Test: click `Use` on a template, then stop/start a workspace, then clone a shared Python workspace.

  6. **No Stop button** — Running workspaces now have a stop button on the dashboard.  
  Test: click the stop icon and make sure the workspace changes to `stopped`.

  7. **Start button did not fully work** — Stopped workspaces now start properly and open the IDE again.  
  Test: stop a workspace, then click `Start`.

  8. **No Delete button** — Workspaces now have a delete button with a confirmation prompt.  
  Test: click the trash icon, confirm, and make sure the workspace disappears.

  9. **Restart could break the Open button** — Stopping and starting a workspace could leave the dashboard pointing at the wrong place. Now the dashboard saves the new address after restart.  
  Test: stop a workspace, start it again, then click `Open`.

  10. **Activity tab was empty** — It used to show only a placeholder. Now it shows real activity like launches, stops, shares, clones, and deletes.  
  Test: do a few actions, then click the `Activity` tab.

  11. **Shared files could come back garbled** — Cloned workspaces could end up with broken file contents. Now shared files come through cleanly.  
  Test: share a Python workspace, clone it, and open a few files to make sure they look normal.

  12. **File restore could break on tricky content** — Some file contents could confuse the restore process. Now restore is done in a safer way.  
  Test: share a Python workspace with normal code files and clone it.

  13. **Failed workspace commands could look successful** — Some internal command failures could act like they worked when they really didn’t. Now failed commands show up as real failures.  
  Test: run a bad command in a workspace flow that depends on it and confirm it reports an error instead of fake success.

  14. **MERN image name was wrong** — The app could look for the wrong MERN image name when launching a MERN workspace. Now it uses the correct name.  
  Test: launch a MERN workspace on the demo machine.

**Demo Notes**

- Sharing/cloning is for **Python workspaces only**.
- The second browser must be **logged in** to clone.
- The share link works best in another browser/profile on the **same computer**, not another laptop.
------------

What works now:

1. **Log in and open the dashboard**  
   You can sign in and land on the dashboard.

2. **Create a new workspace**  
   You can click `Use` on a template and the app creates the workspace for you.

3. **The IDE opens automatically**  
   When the workspace is ready, a new browser tab opens with the IDE.

4. **See your workspace on the dashboard**  
   After it is created, the workspace shows up in your list on the dashboard.

5. **Open an existing workspace again**  
   You can click `Open` on a running workspace and go back into the IDE.

6. **Stop a workspace**  
   You can stop a running workspace from the dashboard.

7. **Start a stopped workspace again**  
   You can restart it and the IDE opens again.

8. **Delete a workspace**  
   You can remove a workspace from the dashboard with the delete button.

9. **See recent activity**  
   The Activity tab now shows real actions like creating, starting, stopping, sharing, cloning, and deleting.

10. **Share a Python workspace**  
   If the workspace is Python and running, you can generate a share link.

11. **Open the share link preview page**  
   The shared link opens a preview page that shows what is inside the workspace.

12. **Clone the shared workspace**  
   If you are logged in, you can make your own copy of that shared Python workspace.

13. **The cloned IDE opens automatically**  
   After cloning, your copied workspace opens in a new tab.

14. **Revoke a share link**  
   You can revoke the current share link for that workspace.

The important limits right now are:
- sharing/cloning is for **Python workspaces**
- cloning requires the user to be **logged in**
- the shared IDE flow works on the **same computer**, not another machine, because the IDE still opens on `localhost`